### PR TITLE
Fixed mobile layout in HeroSection

### DIFF
--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -62,25 +62,25 @@ const HeroSection: React.FC<HeroSectionProps> = ({ id, className }) => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6, delay: 0.6 }}
-                className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start"
+                className="flex flex-col items-center sm:flex-row gap-4 sm:justify-center lg:justify-start"
               >
                 <Link to="/download">
-  <button className="bg-gradient-to-r cursor-pointer from-[#e63946] to-[#ff6b6b] hover:from-[#d62e3b] hover:to-[#e63946] text-white px-8 py-4 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl font-medium flex items-center gap-2">
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="h-5 w-5"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-    >
-      <path
-        fillRule="evenodd"
-        d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
-        clipRule="evenodd"
-      />
-    </svg>
-    Download Now
-  </button>
-</Link>
+                  <button className="bg-gradient-to-r cursor-pointer from-[#e63946] to-[#ff6b6b] hover:from-[#d62e3b] hover:to-[#e63946] text-white px-8 py-4 rounded-full transition-all duration-300 shadow-lg hover:shadow-xl font-medium flex items-center gap-2">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-5 w-5"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    Download Now
+                  </button>
+                </Link>
 
                 <a href="#demo">
                   <button className="border-2 border-[#e63946] hover:bg-[#e63946]/10 text-[#e63946] px-8 py-4 rounded-full transition-all duration-300 font-medium flex items-center gap-2 cursor-pointer">


### PR DESCRIPTION
Key changes made:

    Added items-center to the flex container to center the buttons horizontally in mobile view (flex-col)

    Kept sm:justify-center for small screens and above when the layout switches to row

    Maintained lg:justify-start for large screens as per your original requirement